### PR TITLE
Implement simple POST API deployed on AWS

### DIFF
--- a/backend/lambda/simplePing/index.js
+++ b/backend/lambda/simplePing/index.js
@@ -1,0 +1,50 @@
+//TODO: Connect DynamoDB destination
+const AWS = require("aws-sdk");
+const dynamo = new AWS.DynamoDB.DocumentClient();
+
+exports.handler = async (event, context) => {
+    let body;
+    let statusCode=200;
+    console.log(event)
+    
+    const headers = {
+        "Content-Type": "application/json"
+    };
+    
+    try {
+        switch (event.routeKey) {
+            case "GET /test":
+                body = ( [{
+                'id': 1,
+                'title': 'Hello from Lambda',
+                'description': 'Coming from Lambda in AWS'
+            },
+            {
+                'id': 2,
+               'title': 'Random Text',
+                'description': 'Random description'
+            }
+            ])
+            break;
+            case "POST /test":
+                let requestJSON = JSON.parse(event.body);
+                statusCode = 404;
+                body = (`"${event.routeKey}" route. Request received- no db connection`)
+            break;
+            
+            default:
+                throw new Error(`Unsupported route: "${event.routeKey}"`)
+        }
+    } catch (err) {
+        statusCode = 400;
+        body = err.message;
+    } finally {
+        body = JSON.stringify(body)
+    }
+    
+    return {
+        statusCode,
+        body,
+        headers
+};
+};


### PR DESCRIPTION
closes #7 Implement simple POST API deployed on AWS

As a developer, I want to deploy an HTTP POST ping API, so that I can verify the server responds when I send a request.

### AC:

- simple PING API: checking if the server is there.
- Use URL to send post HTTP POST request and server responds with status code and body.

### Activities / Time Estimates:
**Research P1** (Investigated which options to host API, what type): 1 hour
**Meet with Devops** (Discuss API gateway/lambda): 1 hour
**Create** (in AWS console:): new API gateway, and integrate with new Lambda function trigger: 30 minutes
**Research P2** (API gateway with HTTP API and Lambda): 2 hours
**Develop** (Lambda function ): 1 hour 
**Add Route integration**: 10 minutes
**Revision** based on front end team and fixed CORS issue: 2? hours
**PR** 1 hour


### Test Case 1:

1. Open URL `https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test` in browser
2. Verify response from the server (JSON body with sample mock data)

### Test Case 2:
Prerequisites:
Postman installed or Postman account to use web browser

1. Create a new request by clicking the plus icon in the tabs section
2. Enter request URL: `https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test`
3. Press Send
4. The response body will show with sample JSON data
![httppost_step4](https://user-images.githubusercontent.com/49288075/151108009-64fa7ad1-2283-4196-b3f0-a5a61bb839d1.PNG)

5. Change the “GET” method to “POST” (drop-down is next to URL). 
6. POST options:
      - Select the “Body” tab under the URL
      - “raw”
      - JSON on the dropdown 
7. Enter simple JSON e.g. [{“id”:1}] 
8. Press the “send” button
9. Server responds with body and status code. example:

![httppost_step8](https://user-images.githubusercontent.com/49288075/151108275-deeef84e-d2ef-4bcf-bbf8-0a3695ce3306.PNG)

