### PR TITLE
add options method to ping api

### DIFF
--- a/backend/lambda/simplePing/index.js
+++ b/backend/lambda/simplePing/index.js
@@ -6,7 +6,6 @@ exports.handler = async (event, context) => {
     let body;
     let statusCode=200;
     console.log(event)
-    
     const headers = {
         "Content-Type": "application/json"
     };
@@ -28,12 +27,12 @@ exports.handler = async (event, context) => {
             break;
             case "POST /test":
                 let requestJSON = JSON.parse(event.body);
-                statusCode = 404;
-                body = (`"${event.routeKey}" route. Request received- no db connection`)
+                body = (`POST request success `)
             break;
-            
-            default:
-                throw new Error(`Unsupported route: "${event.routeKey}"`)
+            case "OPTIONS /test":
+                body = (`successfully hit options`)
+                break;
+        
         }
     } catch (err) {
         statusCode = 400;


### PR DESCRIPTION
closes #50 
Fix API issue: Add OPTIONS method to pass pre-flight cors error.
AC:
- OPTIONS requests respond with HTTP/ 200 success

Time:
| Task | Time | Description |
|------|----------|---------|
| Update API | 5 min | Add OPTIONS method to lambda function and the route to the gateway |
| Test | 5 min | Test URL using curl and front end component |
| PR | 5 min | Create PR |


Test Case:
1. Open cmd prompt
2. Use this to test:
`curl -X OPTIONS -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: content-type" -H "Origin: localhost" -v https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test`
3. Verify that the request went through
![image](https://user-images.githubusercontent.com/49288075/152665958-08ef9c90-b950-4ff5-9b0d-dfcffcf356ed.png)
![image](https://user-images.githubusercontent.com/49288075/152666127-bb279b7f-d6a2-417d-97f7-06214ae642f8.png)

