### PR TITLE
Updates export script with CL arguments and auto-export to s3

### DIFF
--- a/floop-data-export.py
+++ b/floop-data-export.py
@@ -71,3 +71,4 @@ if __name__ == '__main__':
     s3object.put(
         Body=(bytes(json.dumps(new_arr).encode('UTF-8'))), ContentType='application/json'
     )
+    

--- a/floop-data-export.py
+++ b/floop-data-export.py
@@ -1,41 +1,55 @@
+import sys
+import boto3
+import argparse
 import firebase_admin
 from firebase_admin import credentials
 from firebase_admin import firestore
 import json
-import os
 
-# Get path of firebase cert from user. Prompt user if path doesnt exist
-while True:
-    certLoc = input('Enter full path of Floop Firebase cert file: ')
-    gPath = os.path.isfile(certLoc)
+# Initiate Argparse for command line arguments and instructions for '--help'.
+parser = argparse.ArgumentParser(description='Using the data-export script.')
+parser.add_argument("fp", type=str,
+                    help="1st arg: This is the credentials filepath variable")
+parser.add_argument("db", choices=["Dev", "Prod"],
+                    type=str, help="2nd arg: Floop db to export from ('Dev'|'Prod')")
 
-    if(gPath):
-        break
-    else:
-        print('File not found, please re-enter file path')
+args = parser.parse_args()
+fp = args.fp
+dbase = args.db
+print('filepath: ' + fp + '\ndatabase: ' + dbase)
 
-# Use cert file to initialize app access and
-#   connect to Dev_Database Conversations collection
-cred = credentials.Certificate(certLoc)
-firebase_admin.initialize_app(cred)
+# Try clause to handle exceptions should firebase credentials path not be valid.
+#    On Exception, will display clear instructions and exit gracefully.
+#    On success, will initialize floop db connection, and pull feedback comments.
+try:
+    cred = credentials.Certificate(fp)
+    pass
+except Exception as e:
+    print("Oops!", e.__class__, "occurred.")
+    sys.exit('File not found, check Floop credentials file path and try again.')
+else:
+    firebase_admin.initialize_app(cred)
+    
+    db = firestore.client()
 
-db = firestore.client()
-
-# pull conversation documents where 'Comment_Preview' field isn't certain
+    collection = 'Databases/{}_Database/Conversations'.format(dbase)
+    conditionals = ['What is your goal for this year?',
+                'Audio Comment', 'Freeform', 'Freeform Comment', '', ' ']
+    
+# Pull conversation documents where 'Comment_Preview' field isn't certain
 #   text, and pulling a limit of 10k.
-conversations = db.collection(
-    'Databases/Dev_Database/Conversations').where('Comment_Preview', 'not-in', [
-        'What is your goal for this year?', 'Audio Comment', 'Freeform', 'Freeform Comment', '', ' ']).limit(10000).get()
+    conversations = db.collection(collection).where(
+        'Comment_Preview', 'not-in', conditionals).limit(1000).get()
 
 if __name__ == '__main__':
 
-    # Iniialize empty list, "cList"
+# Iniialize empty list, "cList"
     cList = []
+    
 # For each item in Conversations, ea entry has a Messages collection
 # all documents will be ordered by 'Date_Submitted' and only the first comment will be pulled.
 # For each document in the pulled list(currently limited to 1 per collection),
 #    get value of "Text" field and add to cList
-
     for convo in conversations:
         convo_entries = convo.reference.collection(
             'Messages').order_by(u'Date_Submitted').limit(1).get()
@@ -49,6 +63,11 @@ if __name__ == '__main__':
     arr = set(cList)
     new_arr = list(arr)
 
-# Write contents of list to json file
-    with open('floop-conv-data.json', 'w') as f:
-        json.dump(new_arr, f)
+# Initiate s3 connection to desired bucket and default object filename.
+    s3 = boto3.resource('s3')
+    s3object = s3.Object('ad440-mpg-floop-export-storage', 'auto-floop-s3-export.json')
+
+# Put json of list into object and put into s3 bucket.
+    s3object.put(
+        Body=(bytes(json.dumps(new_arr).encode('UTF-8'))), ContentType='application/json'
+    )


### PR DESCRIPTION
Closes #51.  ([Improve the export script with command line arguments and upload to S3 bucket](https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/issues/51))

## Description
- Updates the Floop DB export script to remove manual user entry of floop credentials filepath and desired DB to pull from, and makes them Command Line arguments added when executing the script.
- Changes the output from a created json file that had to be manually added to S3, to automatically creating the json file object in the S3 bucket instead.

   _*NOTE: This code operates on the Dev\_Database, not their Prod\_Database, which we do not have access to. For Production DB comments, this code should be sent to a Floop team member to run on the Prod DB._

## Prerequisites
- **Imports:** In terminal, run the following if not already installed:
_NOTE: you may need to go to the project root folder and launch a virtual environment for the imports to be found._ 
  - `pip install firebase-admin`
  - `pip install boto3`
- **Floop Credentials**
  - Floop Firebase private key cert file. Contact Floop team for Firebase console access.
    - _To generate your own key cert file_ (if you have Floop firebase console access): 
      - In Console, select the setting icon in the top of the left side nav, next to "Project Overview".
      - Select "Project Settings" from the slide-out nav menu.
      - From the top nav, select "Service Accounts".
      - In the "Admin SDK configuration snippet" section, select "Python".
      - Click the "Generate new private key" button to generate and download cert file.
    - _Use existing key cert file_: Contact @ZenSorcere to borrow his for testing.
- **AWS Credentials**
  - Boto3 has ([established processes for finding existing credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)). If you have not configured yours using the AWS CLI, you can do so following the instructions ([here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)).
    - after installing the AWS CLI, you run `aws configure` and follow the prompts to enter your AWS key/secret key information.
  - You can confirm you have successfully configured your credentials by locating the credentials file at `~/.aws/credentials`, where `~` is your root folder(for example, "C:\Users\Profile").
     
## Steps to Verify
1. Run script, with command lines arguments for filepath and desired database in the following format: `floop-data-export.py <filepath> <database>`
![image](https://user-images.githubusercontent.com/49133101/153515961-afa965fe-3941-4de5-852d-693f04e10dd1.png)

    1. To see Command Line argument instructions, enter `floop-data-export.py --help`:
![image](https://user-images.githubusercontent.com/49133101/153517007-f82a68cb-ac90-4a5e-b9df-464573d4b100.png)

    2. If the filepath is incorrect and Floop credentials cannot be found, the entered arguments will be displayed, followed by an Error message and you will be prompted to double check the file path:    
![image](https://user-images.githubusercontent.com/49133101/153517288-3f5f4d7c-357d-4feb-95e9-b957f9a951bf.png)

    3. If the desired database is not specifically "Dev" or "Prod", the help instructions reminder will appear:
![image](https://user-images.githubusercontent.com/49133101/153517490-2f4ae543-9aad-4c72-8679-f11ab0cd4586.png)

2. Upon successful script run completion, you will see just the output of what filepath and desired db was entered:
![image](https://user-images.githubusercontent.com/49133101/153516829-ad1f685b-e1ba-4761-95bc-587f4485db46.png)

3. Log into the AWS Console and the S3 bucket: [ad440-mpg-floop-export-storage](https://s3.console.aws.amazon.com/s3/buckets/ad440-mpg-floop-export-storage?region=us-west-2&tab=objects)
4. Verify the file (`auto-floop-s3-export.json`) has been uploaded, noting the timestamp:
![image](https://user-images.githubusercontent.com/49133101/153518677-b6e4a275-af96-4ca3-88a9-f1b41dec8fa2.png)
