### PR TITLE
85 nwc sagemaker cleanup script

### DIFF
--- a/devops/DeleteSagemakerStacks/deleteSagemakerStacks.py
+++ b/devops/DeleteSagemakerStacks/deleteSagemakerStacks.py
@@ -1,0 +1,63 @@
+import boto3
+import argparse
+
+# main driver function that identifies and deletes SageMaker stacks
+# argument --region: the AWS region for the CloudFormation client
+# argument --prefix: add a prefix to narrow results to specific stacks for testing
+# argument --live_run: add this flag to confirm deleted of identified stacks on program execution
+# argument --confirm_delete: add this flag to wait for confirmation of each completed stack (slow)
+def main():
+    
+    # create arguments for AWS region, flag for live run, and flag for confirm stack deletion
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--region', type = str, required=True, help='AWS region for CloudFormation client')
+    parser.add_argument('--prefix', type=str, help='enter a prefix to be added to the sagemaker search string for testing purposes')
+    parser.add_argument('--live_run', action='store_true', help='warning: identified stacks will be deleted on execution')
+    parser.add_argument('--confirm_delete', action='store_true', help='wait for confirmation of deletion for each stack - this will take awhile')
+    args = parser.parse_args()
+    
+    # create CloudFormation client in specified region
+    cf_client = boto3.client('cloudformation', args.region)
+
+    # only check for stacks with these statuses
+    status_filter = ['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'ROLLBACK_COMPLETE']
+
+    # create paginator and iterate through stacks
+    paginator = cf_client.get_paginator('list_stacks')
+    response_iterator = paginator.paginate(StackStatusFilter=status_filter)
+    # store stacks in list
+    stacks = []
+    for response in response_iterator:
+        stacks += [stack['StackName'] for stack in response['StackSummaries']]
+    
+    # find sagemaker stacks
+    query = 'sagemaker'
+    # add prefix to query if provided
+    if args.prefix is not None:
+        query = args.prefix + 'sagemaker'
+    # check stacks with query and add to list
+    sagemaker_stacks = []
+    for stack_name in stacks:
+        if query in stack_name:
+            sagemaker_stacks.append(stack_name)
+    
+    # live_run is off: print identified stacks
+    if args.live_run == False:
+        print('The following SageMaker stacks were identified:')
+        print(sagemaker_stacks)
+        print('To proceed with deletion, run script with --live_run argument')
+    
+    # live_run is on: delete identified stacks
+    if args.live_run == True:
+        for target_stack in sagemaker_stacks:
+            cf_client.delete_stack(StackName=target_stack)
+            print(target_stack + ' deletion started')
+            # wait for confirmation of deletion for each stack (slow)
+            if args.confirm_delete == True:
+                waiter = cf_client.get_waiter('stack_delete_complete')
+                waiter.wait(StackName=target_stack)
+                print(target_stack + ' deleted successfully')
+            
+# run main function
+if __name__ == "__main__":
+    main()

--- a/devops/DeleteSagemakerStacks/deleteSagemakerStacks.py
+++ b/devops/DeleteSagemakerStacks/deleteSagemakerStacks.py
@@ -10,10 +10,14 @@ def main():
     
     # create arguments for AWS region, flag for live run, and flag for confirm stack deletion
     parser = argparse.ArgumentParser()
-    parser.add_argument('--region', type = str, required=True, help='AWS region for CloudFormation client')
-    parser.add_argument('--prefix', type=str, help='enter a prefix to be added to the sagemaker search string for testing purposes')
-    parser.add_argument('--live_run', action='store_true', help='warning: identified stacks will be deleted on execution')
-    parser.add_argument('--confirm_delete', action='store_true', help='wait for confirmation of deletion for each stack - this will take awhile')
+    parser.add_argument('--region', type = str, required=True, \
+        help='AWS region for CloudFormation client')
+    parser.add_argument('--prefix', type=str, \
+        help='enter a prefix to be added to the sagemaker search string for testing purposes')
+    parser.add_argument('--live_run', action='store_true', \
+        help='warning: identified stacks will be deleted on execution')
+    parser.add_argument('--confirm_delete', action='store_true', \
+        help='wait for confirmation of deletion for each stack - this will take awhile')
     args = parser.parse_args()
     
     # create CloudFormation client in specified region


### PR DESCRIPTION
### Closes issue #85 

### Overview
- This pull request adds `deploySagemakerStacks.py`
- This file is a cleanup script that searches for all CloudFormation stacks with 'sagemaker' in the stack name and deletes them. The following arguments can be provided at runtime:
   - --region: the AWS region for the CloudFormation client [required]
   - --prefix: add a prefix to narrow results to specific stacks
   - --live_run: add this flag to confirm deleted of identified stacks on program execution
   - --confirm_delete: add this flag to wait for confirmation of each completed stack (slow)
- WARNING: This is a potentially destructive script, exercise caution when running.

### Pre-requisites
- Python Boto3 installed (python -m pip install boto3)
- AWS CLI and proper basic configuration

### To Test
1. To test deletion, you need to create a SageMaker stack with your initials using the automation script in the repo:
   - Open branch or download the scripts: `deploySagemakerNBI.py` and `sagemakerStackTemplate.json`.
   - Run deploySagemakerNBI.py with the two required string arguments: `--initials` and `--region`. Example: `python deploySagemakerNBI.py --initials ntc --region us-west-2`.
   - The script should provide a confirmation message that stack creation has started and then run for some time before returning a successful creation message.
   - Verify that your stack was created by going to CloudFormation in the AWS Console. 
2. In the same branch, find or download `deleteSagemakerStacks.py`.
3. Run script with the one required argument `--region`. Example: `python deleteSagemakerStacks.py --region us-west-2`.
4. Script should output a list of all matching stacks to the console, including the script you created previously.
5. Run the script with arguments for `--region` and `--prefix`, providing your initials used to create the stack as the argument for `--prefix`. Example: `python deleteSagemakerStacks.py --region us-west-2 --prefix ntc-`.
6. Script should output only your stack in the list of identified stacks.
7. Run the script a final time with all arguments provided. CAUTION: This will delete all identified stacks, ensure that your prefix is entered as an argument. Example: `python deleteSagemakerStacks.py --region us-west-2 --prefix ntc- --live_run --confirm_delete`.
9. Console output should indicate your stack is being deleted. After some time a confirmation message will print.
10. Verify that your stack was deleted by going to CloudFormation in the AWS Console.

![deleteSagemakerStacks_py_—_ad440-winter2022-thursday-repo](https://user-images.githubusercontent.com/45498644/156306711-c3961b60-a566-4723-a6e0-486d9442a9ef.png)

### Time Spent
| Activity | Estimate | Actual Time Spent |
| ------ | ------ | ------ |
| Research boto3 CloudFormation methods | 2 hours | 3 hours |
| Write automation script | 3 hours | 3 hours |
| Test automation script  | 1 hour | 30 mins |
| Write documentation | 30 mins | 30 mins |
| Pull request and wrap-up | 30 mins | 30 mins |