### PR TITLE
Dynamo DB Clean up script #84

### DIFF
--- a/devops/DeleteDynamoDBTables/deleteDynamoDBTable.py
+++ b/devops/DeleteDynamoDBTables/deleteDynamoDBTable.py
@@ -1,0 +1,74 @@
+import boto3
+import argparse
+import sys
+
+
+def main():
+    """Main funnction that lists all tables in the specified aws region and propmpts the user to delete a table.
+
+    Keyword arguments:
+    --region :The AWS region where the DyanmoDB table is located
+    --tableName :The name of the table to be deleted
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--region', type=str, required=True,
+                        help='AWS region where the table is located')
+    parser.add_argument('--tableName', type=str,
+                        help='The name of the table to be deleted')
+    args = parser.parse_args()
+    # connect to aws and list all the tables in the selected region
+    client = boto3.client('dynamodb', region_name=args.region)
+    response = client.list_tables()
+
+    # print the table names in the selected region
+    for table in response['TableNames']:
+        print(table)
+    # ask the the user if he wants to delete all the tables in the selected region
+    if args.tableName is None:
+        if input("Do you want to delete all the tables in the selected region?(y/n)") == "y":
+            # call the delete all tables function
+            delete_all_tables(client, response)
+        else:
+            # ask the user to re-run the script with the table name to be deleted
+            print("Please re-run the script with the table name to be deleted")
+            sys.exit(1)
+    else:
+        # call the delete table function
+        delete_table(client, args.tableName, response)
+
+# A function that'll delete all the tables in the selected region
+
+
+def delete_all_tables(client, response):
+    """Delete all the tables in the selected region.
+
+    Keyword arguments:
+    client :The boto3 client object
+    response :The response object from the list_tables function
+    """
+    for table in response['TableNames']:
+        response = client.delete_table(TableName=table)
+        print("All the tables in the selected region have been deleted")
+
+# A function that'll only delete the table specified in the command line argument
+
+
+def delete_table(client, tableName, response):
+    """Delete the table specified in the command line.
+
+    Keyword arguments:
+    client :The boto3 client object
+    tableName :The name of the table to be deleted
+    response :The response from the list_tables function
+    """
+    for table in response['TableNames']:
+        if table == tableName:
+            response = client.delete_table(TableName=tableName)
+            print("The table has been deleted successfully")
+        else:
+            print("The table does not exist")
+
+
+# run the main function
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Closes issue #84 

### Overview
- This pull request adds `deleteDynamoDBTable.py`
- This file is a cleanup script that lists all the DyanamoDB tables in the user-specified region and deletes them. The following arguments can be provided at runtime:
   - --region: The AWS region where the DyanmoDB table is located [required]
   - --tableName: The name of the table to be deleted
- WARNING: There is the option to delete all the tables in the region. So, exercise caution when running.

### Pre-requisites
- Python Boto3 installed (python -m pip install boto3)
- AWS CLI and proper basic configuration

### To Test
1. To test deletion, you first need to create a **DynamoDB table** using the AWS console or the automation script in the repo: 
    - https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/pull/63
   - Verify that your table was created by going to DynamoDb/Tables in the AWS Console. 
2. `git checkout dd-84`
3. `git pull`
4. `cd .\devops\DeleteDynamoDBTables`
5. `python deleteDynamoDBTable.py --region us-west-2` and follow the prompt
Check image below for reference
![image](https://user-images.githubusercontent.com/26123463/156669626-e7119017-5781-4c34-976a-ffe791808665.png)


### Time Spent
| Activity | Estimate | Actual Time Spent |
| ------ | ------ | ------ |
| Research boto3 methods to cleanup DynamoDB resources| 2 hours | 3 hours |
| Write automation script | 3 hours | 3 hours |
| Test automation script  | 1 hour | 1.30 hours |
| Write documentation and making PR |  1hour | 1.30 hours |