### PR TITLE
Issue #92 Update the API to reply with definition from the Swagger

### DIFF
--- a/backend/API/swagger_API.yaml
+++ b/backend/API/swagger_API.yaml
@@ -84,33 +84,55 @@ definitions:
     properties:
       feedback:
         type: "string"
+        description: "Feedback"
+        example: "This is a good feedback"
 
   AIFeedback:
     type: "object"
     properties:
       feedback:
         type: "string"
+        description: "Feedback"
+        example: "This is a good feedback"
       isQuestion: 
         type: "boolean"
+        description: "Feedback type"
+        example: "true"
       isQuestionConfidence:
         type: "number"
         format: "float"
+        description: "Confidence of the feedback"
+        example: "0.8"
       isSentiment:
         type: "string"
+        description: "Sentiment type"
+        example: "Is the sentiment good"
       isSentimentConfidence:
         type: "number"
         format: "float"
+        description: "Confidence of the sentiment"
+        example: "0.6"
       isEmotion: 
         type: "string"
+        description: "Emotion type"
+        example: "Is the emotion good"
       isEmotionConfidence:
         type: "number"
         format: "float"
+        description: "Confidence of the emotion"
+        example: "0.7"
       positiveRating:
         type: "number"
         format: "float"
+        description: "Positive rating"
+        example: "0.4"
       negativeRating:
         type: "number"
         format: "float" 
+        description: "Negative rating"
+        example: "0.5"
       neutralRating:
         type: "number"
         format: "float"
+        description: "Neutral rating"
+        example: "0.5"

--- a/backend/API/swagger_API.yaml
+++ b/backend/API/swagger_API.yaml
@@ -88,6 +88,23 @@ definitions:
   AIFeedback:
     type: "object"
     properties:
+      feedback:
+        type: "string"
+      isQuestion: 
+        type: "boolean"
+      isQuestionConfidence:
+        type: "number"
+        format: "float"
+      isSentiment:
+        type: "string"
+      isSentimentConfidence:
+        type: "number"
+        format: "float"
+      isEmotion: 
+        type: "string"
+      isEmotionConfidence:
+        type: "number"
+        format: "float"
       positiveRating:
         type: "number"
         format: "float"


### PR DESCRIPTION
issue [#92]   - Update the API to reply with the definition from the Swagger.

Description: 
Made changes on the swagger_API.yaml file and the following changes are returned in the API.
- The feedback itself
- Was the feedback a question + confidence level
- What was the feedback's sentiment + confidence level
- What was the feedback's emotion + confidence level 

To test:
used the Swagger editor and display the definitions returned the result like so:
 
![image](https://user-images.githubusercontent.com/38993144/156838331-343c6fdb-e69d-4d50-ac46-9d63159a153d.png)

Expected time to spent: 12 hours
Time Spent: 
- research about Lambda and API gateway: 7 hours
- modifying the swagger API: 3 hours
- re-update swagger as per the comment from reviewers: 3 hours
 


