### PR TITLE
Upgrade the dynamoDB tables clean up script to run without manual interference(issue 117)

### DIFF
--- a/devops/DeleteDynamoDBTables/deleteDynamoDBTable.py
+++ b/devops/DeleteDynamoDBTables/deleteDynamoDBTable.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python3
+# Path: devops\DeleteDynamoDBTables\deleteDynamoDBTable.py
+
+from tabnanny import check
 import boto3
 import argparse
-import sys
 
 
 def main():
@@ -9,35 +12,33 @@ def main():
     Keyword arguments:
     --region :The AWS region where the DyanmoDB table is located
     --tableName :The name of the table to be deleted
+    --forceDelete :Force delete the table in the selected region
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('--region', type=str, required=True,
                         help='AWS region where the table is located')
     parser.add_argument('--tableName', type=str,
                         help='The name of the table to be deleted')
+    parser.add_argument('--forceDelete', action='store_true',
+                        help='warning: This will force delete all the tables in the selected region')
     args = parser.parse_args()
     # connect to aws and list all the tables in the selected region
     client = boto3.client('dynamodb', region_name=args.region)
     response = client.list_tables()
 
-    # print the table names in the selected region
+  # print the table names in the selected region
     for table in response['TableNames']:
         print(table)
-    # ask the the user if he wants to delete all the tables in the selected region
-    if args.tableName is None:
-        if input("Do you want to delete all the tables in the selected region?(y/n)") == "y":
-            # call the delete all tables function
-            delete_all_tables(client, response)
-        else:
-            # ask the user to re-run the script with the table name to be deleted
-            print("Please re-run the script with the table name to be deleted")
-            sys.exit(1)
-    else:
-        # call the delete table function
+
+  # if --forceDelete is specified, call the delete all tables function
+    if args.forceDelete:
+        delete_all_tables(client, response)
+    # if --tableName is specified call the delete table function
+    elif args.tableName is not None:
         delete_table(client, args.tableName, response)
 
-# A function that'll delete all the tables in the selected region
 
+# A function that'll delete all the tables in the selected region
 
 def delete_all_tables(client, response):
     """Delete all the tables in the selected region.


### PR DESCRIPTION
### Closes issue #117 

### Overview
- This pull request upgrades `deleteDynamoDBTable.py`
- This file will allow the user to list and delete the DynamoDB tables through command-line arguments with any manual intervention.   The following arguments can be provided at runtime:
   - `--region`: AWS region where the table resides.
   -  `--forceDelete`: To force delete all the tables that exist in the selected region.
   -  `--tableName:` To specifically delete a certain table in the selected region.

- You can read the docstrings in this python file to get an in-depth understanding of each function and argument in this file.

### Pre-requisites
- boto3 installed: `pip install boto3`
- AWS CLI properly configured with your credentials: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
### To Test
1. `git checkout 117/dd/enhacement/dynamoCleanUp-script`
2. `cd devops/DeleteDynamoDBTables`
3. Run the script with an arguments  to confirm functionality: 
 - To List all the tables: `python deleteDynamoDBTable.py --region us-west-2`
 - To specificall delete a table: `python deleteDynamoDBTable.py --region us-west-2 --tableName [Desired Table name]`
 - To force delete all the table in the region: `python deleteDynamoDBTable.py --region us-west-2 --forceDelete`
5. Script should run and output the results of testing to the terminal:
![image](https://user-images.githubusercontent.com/26123463/158694571-6bd15800-351d-4cdf-8864-77a6dd5264c7.png)
6. Check you AWS console to double check results.

### Time Spent
| Activity | Estimate | Actual Time Spent |
| ------ | ------ | ------ |
| Research common ways to force delete an AWS resource  | 3 hours | 2 hours |
| Write script | 2 hours | 2 hours |
| Testing script   | 2 hours | 1 hour |
| Write documentation| 30 mins | 30 mins |
| Pull request and wrap-up | 30 mins | 45 mins |