### PR TITLE
DeletingAllS3BucketsIssue116.py

### DIFF
--- a/devops/DeleteAllS3BucketsIssue116.py
+++ b/devops/DeleteAllS3BucketsIssue116.py
@@ -3,5 +3,9 @@
 
 import boto3
 client = boto3.client('s3')
+response = client.list_buckets()
+for name in response ['Buckets']:
+    print (name['Name'])
+
 response = client.delete_buckets()
 print(response)

--- a/devops/DeleteAllS3BucketsIssue116.py
+++ b/devops/DeleteAllS3BucketsIssue116.py
@@ -1,0 +1,7 @@
+#s3BucketDelete.py for issue 87 Create a cleanup script for all s3 buckets 1jc
+#revision for issue 116 Sprint 4 Fix issue #87 Fix script to delete all s3 buckets even with data 1jc
+
+import boto3
+client = boto3.client('s3')
+response = client.delete_buckets()
+print(response)


### PR DESCRIPTION
1jc for Issue 116 Sprint 4   " Issue 116 Fix script to delete all s3 buckets even with data"

fix #116 

DATA ISSUE
The need script to list the s3 buckets and delete such buckets this issue fixes bug in issue 87

SCOPE

write python script for s3 bucket deleting.

Major Obstacles:

Instructor tested PR Thursday March 3, 2022. s3BucketList.py worked fine. s3BucketDelete.py worked but he wanted me to fix the script it where it should be automated versus original script deleting each bucket one by one making sure the bucket is empty.

Resolved Obstacle:

https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/issues/116
This is a bug in the https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/issues/87
The script doesn't delete all S3 buckets but only one
The script requires manual input and cannot be run from an automation machine. This should be changed to command line parameters
.
Instructor issued another issue which is issue https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/issues/116 Fix the script to delete all s3 buckets even with data in connection there is a bug in issue 87 .

Project report for Instructor
Project Duration Sprint 4:  March 3 to March 14 2022
Coordination: DevOps Team issue assigned to 1jc
Report Date: March 14, 2022
Assumptions: N/A