### PR TITLE
Call the API with custom domain 

### DIFF
--- a/frontend/src/components/SubmitBtn/SubmitBtn.js
+++ b/frontend/src/components/SubmitBtn/SubmitBtn.js
@@ -1,7 +1,7 @@
 import { trackPromise } from "react-promise-tracker";
 
 export default function SubmitBtn({ input, setShow, setAIfeedback }) {
-  const url = "https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test";
+  const url = "https://api.seredium.com/v1/feedback";
 
   const handleSubmit = evt => {
     evt.preventDefault();


### PR DESCRIPTION
This PR is to call the custom API -  Closes [#126](https://github.com/North-Seattle-College/ad440-winter2022-thursday-repo/issues/126)

- I think since the API is not public, we cannot get data or send data to it.
- Here is the proof:
<img width="1440" alt="Screen Shot 2022-03-16 at 6 16 40 PM" src="https://user-images.githubusercontent.com/64844662/158717464-d248869f-1e44-448a-8e35-9a50985b988e.png">


Time:
Estimate: 10 min
Actual: 1 hr ( including find out about the error and [collaborating](url) with other student that has the custom domain task ) 