### PR TITLE
Create and run script that deletes all API Gateway resources

### DIFF
--- a/devops/DeleteApiGateway/deleteApiGateway.py
+++ b/devops/DeleteApiGateway/deleteApiGateway.py
@@ -42,9 +42,9 @@ def delete_all_apis(client, response):
     client :The boto3 client object
     response :The response object from the list_apis function
     """
-#     for api in response['items']:
-#         response = client.delete_rest_api(restApiId=api['id'])
-#         print("All the api gateways in the selected region have been deleted")
+    for api in response['items']:
+        response = client.delete_rest_api(restApiId=api['id'])
+        print("All the api gateways in the selected region have been deleted")
 
 
 # # run the main function

--- a/devops/DeleteApiGateway/deleteApiGateway.py
+++ b/devops/DeleteApiGateway/deleteApiGateway.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Path: devops\DeleteApiGateway\deleteApiGateway.py
+
+from tabnanny import check
+import boto3
+import argparse
+
+
+def main():
+    """Main funnction that lists all api gateways and deletes them.
+
+    Keyword arguments:
+    --region :The AWS region where the api gateway is located
+    --forceDelete :Force delete the api gateway in the selected region
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--region', type=str, required=True,
+                        help='AWS region where the api gateway is located')
+    parser.add_argument('--forceDelete', action='store_true',
+                        help='warning: This will force delete all the api gateways in the selected region')
+    args = parser.parse_args()
+    # connect to aws and list all the api gateways in the selected region
+    client = boto3.client('apigateway', region_name=args.region)
+    response = client.get_rest_apis()
+
+    # print the api gateway names in the selected region
+    for api in response['items']:
+        print(api['name'])
+    # delete all the api gateways in the selected region
+    if args.forceDelete:
+        delete_all_apis(client, response)
+    # else tell the re-run the script with --forceDelete and exit
+    else:
+        print("Please re-run the script with --forceDelete and try again")
+        exit()
+
+
+def delete_all_apis(client, response):
+    """Delete all the api gateways in the selected region.
+
+    Keyword arguments:
+    client :The boto3 client object
+    response :The response object from the list_apis function
+    """
+#     for api in response['items']:
+#         response = client.delete_rest_api(restApiId=api['id'])
+#         print("All the api gateways in the selected region have been deleted")
+
+
+# # run the main function
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Closes issue #153 

### Overview
- This pull request adds `deleteApiGateway.py`
- This file will list and delete all the API Gateway resources through command-line arguments.   The following arguments can be provided at runtime:
   - `--region`: AWS region where the API gateway resides.
   -  `--forceDelete`: To force delete all the API gatewa that exist in the selected region.

- You can read the docstrings in this python file to get an in-depth understanding of each function and arguments in this file.

### Pre-requisites
- boto3 installed: `pip install boto3`
- AWS CLI properly configured with your credentials: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
### To Test
1. `git checkout dd-153`
2. `cd devops/DeleteApiGateway`
3. Run the script with an arguments  to confirm functionality: 
 - To List all the API gateways: `python deleteApiGateway.py --region us-west-2`
 - To force delete all the API gateways in the region: `python deleteApiGateway.py --region us-west-2 --forceDelete
4. Go to your AWS console/services/API Gateway and make sure no API gateway resource exists.

                                          Terminal output from running the cleanup script
![image](https://user-images.githubusercontent.com/26123463/160226247-e2210a50-425b-44c3-9152-81c4797707ab.png)


                Screenshot from AWS console showing that no resources are left(Only APIs gateways created in 2022 are deleted)
![image](https://user-images.githubusercontent.com/26123463/160226284-753203c6-30fc-47b3-a400-7b6ce0f838e3.png)



### Time Spent
| Activity | Estimate | Actual Time Spent |
| ------ | ------ | ------ |
| Researching and writing script | 3 hours | 2 hours |
| Testing script   | 1 hour | 1 hour |
| Write documentation| 30 mins | 30 mins |
| Pull request and wrap-up | 30 mins | 30mins |




